### PR TITLE
move to @xmldom/xmldom to address CVE-2021-32796

### DIFF
--- a/nodejs/scripts/package-lock.json
+++ b/nodejs/scripts/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "@mitre/jsonix",
-	"version": "3.0.1-SNAPSHOT",
+	"version": "3.0.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@mitre/jsonix",
-			"version": "3.0.1-SNAPSHOT",
+			"version": "3.0.2",
 			"dependencies": {
+				"@xmldom/xmldom": "^0.8.2",
 				"amdefine": "^0.0.4",
-				"xmldom": "^0.6.0",
 				"xmlhttprequest": "^1.8.0"
 			},
 			"devDependencies": {
@@ -218,6 +218,14 @@
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.0.3",
 				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
+		},
+		"node_modules/@xmldom/xmldom": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.2.tgz",
+			"integrity": "sha512-+R0juSseERyoPvnBQ/cZih6bpF7IpCXlWbHRoCRzYzqpz6gWHOgf8o4MOEf6KBVuOyqU+gCNLkCWVIJAro8XyQ==",
+			"engines": {
+				"node": ">=10.0.0"
 			}
 		},
 		"node_modules/ajv": {
@@ -2585,14 +2593,6 @@
 				"signal-exit": "^3.0.2"
 			}
 		},
-		"node_modules/xmldom": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-			"integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
 		"node_modules/xmlhttprequest": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
@@ -2812,6 +2812,11 @@
 				"@jridgewell/resolve-uri": "^3.0.3",
 				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
+		},
+		"@xmldom/xmldom": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.2.tgz",
+			"integrity": "sha512-+R0juSseERyoPvnBQ/cZih6bpF7IpCXlWbHRoCRzYzqpz6gWHOgf8o4MOEf6KBVuOyqU+gCNLkCWVIJAro8XyQ=="
 		},
 		"ajv": {
 			"version": "6.12.6",
@@ -4748,11 +4753,6 @@
 				"imurmurhash": "^0.1.4",
 				"signal-exit": "^3.0.2"
 			}
-		},
-		"xmldom": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-			"integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg=="
 		},
 		"xmlhttprequest": {
 			"version": "1.8.0",

--- a/nodejs/scripts/package.json
+++ b/nodejs/scripts/package.json
@@ -50,12 +50,12 @@
 		"test": "nodeunit tests/tests.js"
 	},
 	"dependencies": {
+		"@xmldom/xmldom": "^0.8.2",
 		"amdefine": "^0.0.4",
-		"xmldom": "^0.6.0",
 		"xmlhttprequest": "^1.8.0"
 	},
 	"devDependencies": {
-		"nodeunit": "^0.11.3",
-		"node-static": "^0.7.11"
+		"node-static": "^0.7.11",
+		"nodeunit": "^0.11.3"
 	}
 }


### PR DESCRIPTION
Thank you for forking and updating `jsonix` - there is an open [CVE](https://www.cve.org/CVERecord?id=CVE-2021-32796) on one of its dependencies (xmldom).

Also the `xmldom` npm is no longer published to, and all updates have moved to [@xmldom/xmldom](https://www.npmjs.com/package/@xmldom/xmldom) - this  PR moves to the latest release there which addresses the CVE.