### PR TITLE
Update Jsonix.Context constructor to include options parameter in .d.ts file

### DIFF
--- a/typescript/src/main/typescript/Jsonix.d.ts
+++ b/typescript/src/main/typescript/Jsonix.d.ts
@@ -85,10 +85,10 @@ declare module Jsonix {
         /**
          * Creates an instance of Context.
          *
-         * @param {any[]} s (description)
-         * @param {ContextOptions} options (description)
+         * @param {any[]} mappings Array of mapping modules that define XML/JSON schema definitions
+         * @param {ContextOptions} options Optional configuration options
          */
-        constructor(s:any[], options?:ContextOptions);
+        constructor(mappings:any[], options?:ContextOptions);
 
         /**
          * (description)

--- a/typescript/src/main/typescript/Jsonix.d.ts
+++ b/typescript/src/main/typescript/Jsonix.d.ts
@@ -64,7 +64,7 @@ interface Marshaller { // TODO: generics like marshalString(object:T):string;
 }
 
 declare module Jsonix {
-  export interface ContextOptions {
+    export interface ContextOptions {
         /**
          * Maps namespace URIs to prefixes for XML serialization.
          */
@@ -79,9 +79,9 @@ declare module Jsonix {
          * Defaults to 'standard'.
          */
         mappingStyle?: 'standard' | 'simplified' | Object
-  }
+    }
 
-  export class Context {
+    export class Context {
         /**
          * Creates an instance of Context.
          *

--- a/typescript/src/main/typescript/Jsonix.d.ts
+++ b/typescript/src/main/typescript/Jsonix.d.ts
@@ -64,13 +64,31 @@ interface Marshaller { // TODO: generics like marshalString(object:T):string;
 }
 
 declare module Jsonix {
-    export class Context {
+  export interface ContextOptions {
+        /**
+         * Maps namespace URIs to prefixes for XML serialization.
+         */
+        namespacePrefixes?: { [namespaceUri: string]: string }
+        /**
+         * Whether to support xsi:type attributes during unmarshalling.
+         * Defaults to true.
+         */
+        supportXsiType?: boolean
+        /**
+         * The mapping style to use. Can be a string identifier or a custom mapping style object.
+         * Defaults to 'standard'.
+         */
+        mappingStyle?: 'standard' | 'simplified' | Object
+  }
+
+  export class Context {
         /**
          * Creates an instance of Context.
          *
          * @param {any[]} s (description)
+         * @param {ContextOptions} options (description)
          */
-        constructor(s:any[]);
+        constructor(s:any[], options?:ContextOptions);
 
         /**
          * (description)


### PR DESCRIPTION
Add optional second `options` parameter to `Jsonix.Context` constructor with `namespacePrefixes`, `supportXsiType`, and `mappingStyle` fields. Also rename first parameter from `s` to `mappings`.